### PR TITLE
Fix `eventHandler(_:_:_:)` definition

### DIFF
--- a/Sources/PlaydateSwift/PlaydateSwift.swift
+++ b/Sources/PlaydateSwift/PlaydateSwift.swift
@@ -3,7 +3,7 @@ import CPlaydate
 dynamic public func EventCallback(playdate: PlaydateAPI, event: SystemEvent) {}
 
 @_cdecl("eventHandler")
-public func eventHandler(_ playdate: UnsafePointer<PlaydateAPI>, _ event: PDSystemEvent, _ arg: CInt) -> CInt {
+public func eventHandler(_ playdate: UnsafePointer<PlaydateAPI>, _ event: PDSystemEvent, _ arg: UInt32) -> CInt {
     EventCallback(playdate: playdate.pointee, event: SystemEvent(event))
     return 0
 }

--- a/Sources/PlaydateSwift/PlaydateSwift.swift
+++ b/Sources/PlaydateSwift/PlaydateSwift.swift
@@ -3,7 +3,7 @@ import CPlaydate
 dynamic public func EventCallback(playdate: PlaydateAPI, event: SystemEvent) {}
 
 @_cdecl("eventHandler")
-public func eventHandler(_ playdate: PlaydateAPI, _ event: PDSystemEvent, _ arg: CInt) -> CInt {
-    EventCallback(playdate: playdate, event: SystemEvent(event))
+public func eventHandler(_ playdate: UnsafePointer<PlaydateAPI>, _ event: PDSystemEvent, _ arg: CInt) -> CInt {
+    EventCallback(playdate: playdate.pointee, event: SystemEvent(event))
     return 0
 }


### PR DESCRIPTION
`playdate` should be `UnsafePointer<PlaydateAPI>` because `eventHandler` is defined as follows in pd_api.h:

```c
int eventHandler(PlaydateAPI* playdate, PDSystemEvent event, uint32_t arg);
```

